### PR TITLE
fix: use L+ instead of C+ for tmpfiles rules to apply config changes on rebuild

### DIFF
--- a/nix-dokploy.nix
+++ b/nix-dokploy.nix
@@ -312,15 +312,15 @@ in {
           };
         in [
           "d ${dir} 0755 root root -"
-          "C+ ${dir}/chain.crt 0400 root root - ${cert.certFile}"
-          "C+ ${dir}/privkey.key 0400 root root - ${cert.keyFile}"
-          "C+ ${dir}/certificate.yml - - - - ${certYaml}"
+          "L+ ${dir}/chain.crt - - - - ${cert.certFile}"
+          "L+ ${dir}/privkey.key - - - - ${cert.keyFile}"
+          "L+ ${dir}/certificate.yml - - - - ${certYaml}"
         ])
         cfg.traefik.certificates);
 
       dynamicConfigRules =
         lib.mapAttrsToList (
-          name: value: "C+ ${cfg.dataDir}/traefik/dynamic/${name}.yml - - - - ${yamlFormat.generate "${name}.yml" value}"
+          name: value: "L+ ${cfg.dataDir}/traefik/dynamic/${name}.yml - - - - ${yamlFormat.generate "${name}.yml" value}"
         )
         cfg.traefik.dynamicConfig;
 
@@ -330,7 +330,7 @@ in {
 
       filesRules =
         lib.mapAttrsToList (
-          name: value: "C+ ${cfg.dataDir}/traefik/dynamic/files/${name} - - - - ${value}"
+          name: value: "L+ ${cfg.dataDir}/traefik/dynamic/files/${name} - - - - ${value}"
         )
         cfg.traefik.files;
     in


### PR DESCRIPTION
## Summary
- `C+` tmpfiles rules only create files if they don't already exist, so changes to `traefik.dynamicConfig`, `traefik.certificates`, or `traefik.files` are silently ignored on subsequent `nixos-rebuild switch` runs
- Changed `C+` to `L+` (symlink, always overwrite) for all dynamic config, certificate, and file tmpfiles rules
- Directory creation rules (`d` type) are unchanged

## Problem
When a user modifies their Traefik dynamic config (e.g., adding a TLS certificates block), `nixos-rebuild switch` generates a new Nix store path for the YAML file but tmpfiles `C+` sees the old file on disk and skips it. The only workaround is manually deleting files and re-running `systemd-tmpfiles --create`.

## Test plan
- [ ] Deploy with a `traefik.dynamicConfig` entry, verify file is created
- [ ] Modify the config, run `nixos-rebuild switch`, verify the file is updated
- [ ] Verify `traefik.certificates` symlinks point to the correct host paths
- [ ] Verify `traefik.files` entries are updated on rebuild